### PR TITLE
handle `fedora` in the same way as redhat

### DIFF
--- a/preload.php
+++ b/preload.php
@@ -328,7 +328,7 @@ if (!\function_exists('uv_init')) {
             $version = \trim((string) $os['VERSION_ID']);
             if ($id === 'debian') {
                 $code = $directory . 'headers/uv_ubuntu' . ((float)$version < 20.04 ? '18.04' : '20.04') . '.h';
-            } elseif ($id === 'redhat') {
+            } elseif ($id === 'redhat' || $id === 'fedora') {
                 $code = $directory . 'headers/uv_centos' . ((float)$version < 8 ? '7' : '8+') . '.h';
             }
         }


### PR DESCRIPTION
Based on the contents of the `/etc/os-release` of the rootfs images obtained from [here](https://koji.fedoraproject.org/koji/packageinfo?packageID=26387) fedora-based distros always have the value of `fedora` for `ID_LIKE` (unless they are modified in some way🤷‍♂️ 